### PR TITLE
feat: add openclaw-setup-assistant skill

### DIFF
--- a/src/content/skills/openclaw-setup-assistant.md
+++ b/src/content/skills/openclaw-setup-assistant.md
@@ -1,0 +1,53 @@
+---
+name: openclaw-setup-assistant
+title: OpenClaw 安装助手
+description: OpenClaw 零门槛安装与维护助手。自动检测系统环境，引导完成安装配置，支持接入钉钉/飞书/QQ/Discord 等聊天平台，根据使用场景推荐技能，并提供日常维护支持——全程交互式引导，无需任何终端经验。
+source: community
+author: QoderWork
+githubUrl: https://github.com/Leroy-Zhang/openclaw-setup-assistant
+docsUrl: https://github.com/Leroy-Zhang/openclaw-setup-assistant#readme
+category: automation
+tags:
+    - openclaw
+    - installer
+    - setup-assistant
+    - dingtalk
+    - automation
+    - maintenance
+roles:
+    - developer
+    - new-user
+featured: false
+popular: false
+isOfficial: false
+installCommand: npx skills add https://github.com/Leroy-Zhang/openclaw-setup-assistant -a qoder
+date: 2026-03-09
+---
+
+## 使用场景
+
+- 在本地电脑或远程服务器上从零安装和配置 OpenClaw（支持 macOS、Windows、Linux）
+- 将 OpenClaw 接入聊天平台——钉钉、飞书、QQ 或 Discord
+- 根据你的使用场景，获取个性化的技能推荐
+- 安装后的日常维护：健康检查、故障排查、切换 AI 模型、更新版本
+
+## 示例
+
+```
+# 打开 QoderWork，对它说：
+帮我安装 OpenClaw
+
+# 助手会一步步引导你：
+# 1. 检测你的操作系统和环境
+# 2. 询问你想使用哪个 AI 模型
+# 3. 可选：接入钉钉或其他聊天平台
+# 4. 自动完成安装
+# 5. 验证安装是否成功
+```
+
+## 注意事项
+
+- 专为非技术用户设计——全程语气温暖、鼓励，像朋友一样引导
+- 支持多种 AI 模型：DeepSeek、Anthropic、OpenAI、阿里百炼（含免费 Coding Plan）
+- 内置错误处理，遇到问题自动运行 `openclaw doctor --fix` 诊断修复
+- 每一步都会确认后再执行，绝不擅自操作


### PR DESCRIPTION
## What this PR does

Adds a new community skill: **openclaw-setup-assistant**

### Description

A guided, zero-friction installer and maintenance assistant for OpenClaw. This skill turns QoderWork into a friendly setup guide that helps complete non-technical beginners install and configure OpenClaw — no terminal knowledge required.

### Key features

- Install and configure OpenClaw from scratch on local machines or remote servers (macOS, Windows, Linux)
- Connect OpenClaw to chat platforms — DingTalk, Feishu, QQ, or Discord
- Get personalized skill recommendations based on use case
- Post-installation maintenance: health checks, troubleshooting, model switching, updates

### Skill source repository

https://github.com/Leroy-Zhang/openclaw-setup-assistant

### Install command

```bash
npx skills add https://github.com/Leroy-Zhang/openclaw-setup-assistant -a qoder
```