### PR TITLE
Add coding-agent skill v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,237 @@
-# Qoder Community
+# Coding Agent Skill
 
-Global community platform for Qoder developers - share agents, learn together, build faster.
+将编码任务委托给 Claude Code、OpenCode、iFlow 或 qodercli，通过后台进程运行。
 
-## Tech Stack
+## 前提条件
 
-- **Framework**: [Astro](https://astro.build/) 5.6+
-- **Theme**: [Starlight](https://starlight.astro.build/) 0.37+
-- **Deployment**: [Cloudflare Pages](https://pages.cloudflare.com/)
-- **Language**: TypeScript + Markdown/MDX
+### 必须安装 tmux
 
-## Features
+由于 Bash 工具没有 PTY（伪终端）参数，运行交互式 CLI/TUI 工具（如 OpenCode、iFlow、qodercli 的交互模式）时，需要使用 **tmux** 来提供 PTY 环境。
 
-- Lightning-fast performance (Lighthouse 98-100)
-- Quick builds (~4 seconds)
-- Minimal JavaScript (~2.5KB)
-- Built-in full-text search
-- Dark mode support
-- Fully responsive
-- Global CDN via Cloudflare
-- Free web analytics
-
-## Project Structure
-
-```
-qoder-community/
-├── src/
-│   ├── content/
-│   │   ├── skills/        # Agent skills (English)
-│   │   ├── skills-zh/     # Agent skills (Chinese)
-│   │   ├── agents/        # Community agent configurations
-│   │   ├── videos/        # Tutorial videos
-│   │   ├── meetups/       # Global meetup events
-│   │   ├── showcase/      # Community projects
-│   │   └── docs/          # Site pages
-│   ├── components/
-│   │   ├── AgentCard.astro
-│   │   ├── VideoCard.astro
-│   │   └── MeetupCard.astro
-│   ├── pages/
-│   │   ├── agents.astro
-│   │   ├── learn.astro
-│   │   ├── meetups.astro
-│   │   └── showcase.astro
-│   └── styles/
-│       └── custom.css
-├── public/
-├── astro.config.mjs
-└── package.json
-```
-
-## Local Development
-
-### Install Dependencies
+**安装 tmux：**
 
 ```bash
-npm install
+# macOS
+brew install tmux
+
+# Ubuntu/Debian
+sudo apt install tmux
+
+# CentOS/RHEL
+sudo yum install tmux
 ```
 
-### Start Dev Server
+### 编码代理 CLI 工具
+
+根据需要安装以下一个或多个编码代理：
+
+- **Claude Code**: `claude` CLI
+- **OpenCode**: `opencode` CLI
+- **iFlow**: `iflow` CLI
+- **qodercli**: `qodercli` CLI
+
+## 快速开始
+
+### 一次性任务
+
+对于简单的提示/对话，创建临时 git 仓库并运行：
 
 ```bash
-npm run dev
+# 创建临时工作目录
+SCRATCH=$(mktemp -d) && cd $SCRATCH && git init
+
+# OpenCode 一次性任务
+cd "$SCRATCH" && opencode run '你的提示词'
+
+# iFlow 一次性任务（非交互）
+cd "$SCRATCH" && iflow -p '你的提示词'
+
+# qodercli 一次性任务（非交互）
+cd "$SCRATCH" && qodercli -p '你的提示词'
 ```
 
-Visit: http://localhost:4321
+> **为什么要 git init？** 许多代理 CLI 在 git 仓库中工作效果最佳（支持 diff、patch、历史记录）。临时仓库可以保持工作干净且可复现。
 
-### Build for Production
+## 使用模式
+
+### 核心模式：cd + tmux + capture-pane/send-keys
+
+对于较长的任务，在 tmux 中启动代理，然后使用 bash 运行 tmux 命令进行监控和交互：
 
 ```bash
-npm run build
+# 1) 在目标目录启动代理（tmux 提供 PTY）
+tmux new-session -d -s opencode-1 "cd ~/project && opencode run '构建贪吃蛇游戏'"
+
+# 2) 监控输出（最后 50 行）
+tmux capture-pane -t opencode-1 -p | tail -50
+
+# 3) 安全发送输入（文本然后回车）
+tmux send-keys -t opencode-1 -l -- "yes"
+sleep 0.1
+tmux send-keys -t opencode-1 Enter
+
+# 4) 如需停止
+tmux send-keys -t opencode-1 C-c
+# 或终止 tmux 会话
+tmux kill-session -t opencode-1
 ```
 
-### Preview Build
+## 各代理详细用法
+
+### OpenCode (opencode)
+
+OpenCode 通常是交互式的（TUI），因此**在 tmux 中运行**：
 
 ```bash
-npm run preview
+# 启动 TUI（默认）
+tmux new-session -d -s opencode-1 "cd ~/project && opencode"
+
+# 运行一次性消息
+tmux new-session -d -s opencode-run-1 "cd ~/project && opencode run '添加深色模式切换'"
+
+# 指定模型 / 继续会话
+tmux new-session -d -s opencode-model-1 "cd ~/project && opencode -m zai-coding-plan/glm-4.7 run '重构认证模块'"
+tmux new-session -d -s opencode-continue-1 "cd ~/project && opencode -c"
+tmux new-session -d -s opencode-session-1 "cd ~/project && opencode -s <sessionId>"
+
+# PR 工作流
+tmux new-session -d -s opencode-pr-130 "cd ~/project && opencode pr 130"
 ```
 
-## How to Contribute
+### Claude Code
 
-We currently welcome contributions for **Agent Skills**. Help the community by sharing your specialized skills!
-
-For detailed instructions on how to add and format your skills, please refer to our **[Contributing Guide](CONTRIBUTING.md)**.
-
-## Deployment
-
-### Deploy to Cloudflare Pages
-
-See `DEPLOYMENT.md` for detailed instructions.
-
-Quick steps:
+Claude Code 使用 `--print --permission-mode bypassPermissions` 模式：
 
 ```bash
-# 1. Push to GitHub
-git add .
-git commit -m "Update content"
-git push
+# 前台运行
+cd ~/project && claude --permission-mode bypassPermissions --print '你的任务'
 
-# 2. Cloudflare Pages auto-deploys (1-2 minutes)
+# 后台运行
+# 使用 Bash 工具的 run_in_background: true 参数
 ```
 
-## Contributing
+### iFlow (iflow)
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing agent configurations.
-
-## Links
-
-- **Live Site**: https://qoder-community.pages.dev
-- **GitHub**: https://github.com/Qoder-AI/qoder-community
-- **Astro Docs**: https://docs.astro.build/
-- **Starlight Guide**: https://starlight.astro.build/
-
-## Troubleshooting
-
-### Build Errors
+iFlow 支持交互式和非交互式两种模式：
 
 ```bash
-# Clean and reinstall
-rm -rf node_modules package-lock.json
-npm install
-npm run build
+# 一次性任务（非交互）
+cd ~/project && iflow -p '解释这个仓库的架构并提出 3 个重构建议'
+
+# 提示后保持交互
+tmux new-session -d -s iflow-1 "cd ~/project && iflow -i '扫描仓库并识别风险模式；然后等待后续指令'"
+
+# 会话控制 / 限制
+cd ~/project && iflow -c -p '总结上次发布以来的变更'
+cd ~/project && iflow --max-turns 25 -p '修复失败的测试'
 ```
 
-### Content Not Showing
+### qodercli
 
-Check frontmatter format is correct.
+qodercli 可以作为交互式助手或非交互式"打印后退出"模式运行：
 
-### Search Not Working
+```bash
+# 交互模式
+tmux new-session -d -s qoder-1 "cd ~/project && qodercli -w ~/project"
 
-Check Pagefind output in build logs.
+# 一次性任务（非交互）— 委托任务的首选方式
+# 注意：qodercli 的 -p 模式不需要 PTY，建议使用后台 bash 而非 tmux
+# 因为 tmux capture-pane 对 qodercli 可能返回空内容
+cd ~/project && qodercli -w ~/project -p '你的任务' --max-turns 25 2>&1 | tee /tmp/qoder-task.log
 
----
+# 监控进度
+tail -50 /tmp/qoder-task.log
 
-Powered by Astro and Starlight  
-Hosted on Cloudflare Pages
+# 机器可读输出
+cd ~/project && qodercli -p '总结 src/ 职责' -f json
+```
+
+**处理长提示词或非 ASCII 字符：**
+
+```bash
+# 1) 将提示词写入临时文件
+# 2) 通过 $(cat ...) 传递
+cd ~/project && qodercli -w ~/project -p "$(cat /tmp/my-prompt.txt)" --max-turns 30
+```
+
+## 高级用法
+
+### 使用 git worktree 并行修复多个问题
+
+```bash
+# 1. 为每个问题创建 worktree
+git worktree add -b fix/issue-78 /tmp/issue-78 main
+git worktree add -b fix/issue-99 /tmp/issue-99 main
+
+# 2. 在每个 worktree 中启动代理
+tmux new-session -d -s issue-78 "cd /tmp/issue-78 && pnpm install && opencode run '修复 issue #78'"
+tmux new-session -d -s issue-99 "cd /tmp/issue-99 && pnpm install && iflow -i '修复 issue #99'"
+
+# 3. 监控进度
+tmux list-sessions
+tmux capture-pane -t issue-78 -p | tail -50
+
+# 4. 修复完成后创建 PR
+cd /tmp/issue-78 && git push -u origin fix/issue-78
+gh pr create --repo user/repo --head fix/issue-78 --title "fix: ..." --body "..."
+
+# 5. 清理
+git worktree remove /tmp/issue-78
+git worktree remove /tmp/issue-99
+```
+
+## 重要规则
+
+1. **为每个代理选择正确的执行模式**：
+   - OpenCode/iFlow：在 **tmux** 中运行以获得交互性（PTY）
+   - qodercli 一次性任务（`-p`）：优先使用**直接后台 bash** 配合 `tee` 记录日志
+   - Claude Code：优先使用 `--print --permission-mode bypassPermissions`（非交互）
+
+2. **尊重工具选择** - 如果用户要求使用特定代理 CLI，请使用该 CLI
+
+3. **保持耐心** - 不要因为会话"慢"就终止它
+
+4. **智能监控** - 首先使用 `tmux capture-pane`，如果 10 秒后返回空内容，切换到日志文件（`tee` 输出）
+
+5. **并行是允许的** - 可以为批处理工作运行多个后台会话
+
+6. **永远不要在 ~/ 目录启动代理** - 避免将内部文档纳入上下文
+
+## 常见问题
+
+### capture-pane 返回空内容
+
+某些代理 CLI（特别是 qodercli）使用备用屏幕缓冲区或延迟 stdout，导致 `tmux capture-pane` 返回空白输出。
+
+**解决方案**：使用 `tee` + 日志文件作为主要监控方法：
+
+```bash
+tmux new-session -d -s agent-1 "cd ~/project && agent-cli ... 2>&1 | tee /tmp/agent-task.log"
+tail -50 /tmp/agent-task.log
+```
+
+### 脚手架 CLI 意外阻塞
+
+脚手架工具（create-next-app、create-vite 等）经常在新版本中添加交互提示。
+
+**解决方案**：管道默认答案处理意外提示：
+
+```bash
+echo "no" | npx create-next-app@latest my-app --typescript --tailwind --eslint --app --use-npm
+```
+
+### 区域设置 / 编码问题
+
+Bash 工具环境可能不会继承 UTF-8 区域设置。如果看到乱码，请将提示词写入临时文件并通过 `$(cat /tmp/prompt.txt)` 传递。
+
+## 进度更新
+
+当在后台启动编码代理时，请保持用户知情：
+
+- 启动时发送简短消息（正在运行什么 + 在哪里）
+- 仅在以下情况更新：
+  - 里程碑完成（构建完成、测试通过）
+  - 代理提问 / 需要输入
+  - 遇到错误或需要用户操作
+  - 代理完成（包括变更内容 + 位置）
+- 如果终止会话，立即说明原因

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: coding-agent
+version: 0.1.0
+description: 'Delegate coding tasks to Claude Code, OpenCode, iFlow, or qodercli via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that benefits from agent-driven exploration. NOT for: simple one-liner fixes (just edit), reading a single known file (use file read), thread-bound ACP harness requests in chat, or any work in ~/clawd workspace (never spawn agents here). Claude Code: prefer --print --permission-mode bypassPermissions. OpenCode/iFlow/qodercli: run inside tmux for interactivity (PTY).'
+---
+
+# Coding Agent (bash-first)
+
+Use **bash** + **tmux** for all coding agent work. Simple and effective.
+
+## ⚠️ Interactive CLIs: use tmux to provide a PTY
+
+The bash tool has **no** `pty` parameter. To run interactive CLIs/TUIs like OpenCode / iFlow / qodercli, use **tmux** to provide a PTY, then use `tmux capture-pane` / `tmux send-keys` for monitoring and input.
+
+```bash
+# ✅ Start an interactive CLI inside a tmux session (PTY provided by tmux)
+tmux new-session -d -s opencode-1 "cd /path/to/project && opencode"
+tmux new-session -d -s iflow-1 "cd /path/to/project && iflow"
+tmux new-session -d -s qoder-1 "cd /path/to/project && qodercli -w /path/to/project"
+```
+
+For **Claude Code** (`claude` CLI), use `--print --permission-mode bypassPermissions` instead.
+`--dangerously-skip-permissions` with PTY can exit after the confirmation dialog.
+`--print` mode keeps full tool access and avoids interactive confirmation:
+
+```bash
+# ✅ Correct for Claude Code (no PTY needed)
+cd /path/to/project && claude --permission-mode bypassPermissions --print 'Your task'
+
+# For background execution: use run_in_background:true on the bash tool
+
+# ❌ Wrong for Claude Code
+claude --dangerously-skip-permissions 'task'
+```
+
+### Bash Tool Parameters
+
+| Parameter    | Type    | Description                                                                 |
+| ------------ | ------- | --------------------------------------------------------------------------- |
+| `command`    | string  | The shell command to run                                                    |
+| `run_in_background` | boolean | Run in background (non-blocking)                                     |
+| `timeout`    | number  | Timeout in **milliseconds** (kills process on expiry)                     |
+| `description` | string |  (optional) — A short 5–10 word summary of what the command does, for clarity. |
+
+---
+
+## Quick Start: One-Shot Tasks
+
+For quick prompts/chats, create a temp git repo and run:
+
+```bash
+# Quick chat in a temp repo (safe scratch workspace)
+SCRATCH=$(mktemp -d) && cd $SCRATCH && git init
+
+# OpenCode one-shot
+bash command:"cd \"$SCRATCH\" && opencode run 'Your prompt here'"
+
+# iFlow one-shot (non-interactive)
+bash command:"cd \"$SCRATCH\" && iflow -p 'Your prompt here'"
+
+# qodercli one-shot (non-interactive)
+bash command:"cd \"$SCRATCH\" && qodercli -p 'Your prompt here'"
+
+# Or in a real project - interactive via tmux (PTY)
+bash command:"tmux new-session -d -s opencode-quick \"cd ~/Projects/myproject && opencode run 'Add error handling to the API calls'\""
+```
+
+**Why git init?** Many agent CLIs work best inside a git repo (diffs, patches, history). A temp repo keeps scratch work clean and reproducible.
+
+---
+
+## The Pattern: cd + tmux + capture-pane/send-keys
+
+For longer tasks, start the agent inside tmux (PTY), then monitor and interact using **bash** run tmux command:
+
+```bash
+# 1) Start agent in target directory (PTY provided by tmux)
+tmux new-session -d -s opencode-1 "cd ~/project && opencode run 'Build a snake game'"
+
+# 2) Monitor output (last 50 lines)
+tmux capture-pane -t opencode-1 -p | tail -50
+
+# 3) Send input safely (text then Enter)
+tmux send-keys -t opencode-1 -l -- "yes"
+sleep 0.1
+tmux send-keys -t opencode-1 Enter
+
+# 4) Stop if needed
+tmux send-keys -t opencode-1 C-c
+# or kill the tmux session
+tmux kill-session -t opencode-1
+```
+
+**Why `cd` matters:** Our bash tool has no `workdir`, so you must `cd` explicitly to scope context and side effects.
+
+### ⚠️ Fallback: when `capture-pane` returns empty
+
+Some agent CLIs (notably **qodercli**) use alternate screen buffers or defer stdout, making `tmux capture-pane` return blank output even while the agent is actively working. If capture-pane is empty after 10+ seconds but the process is still running:
+
+1. **Don't assume the agent is stuck** — check the log file or process status first.
+2. **Use `tee` + log file** as the primary monitoring method:
+   ```bash
+   # Start with tee to capture output to a log file
+   tmux new-session -d -s agent-1 "cd ~/project && agent-cli ... 2>&1 | tee /tmp/agent-task.log"
+   # Monitor via log file instead of capture-pane
+   tail -50 /tmp/agent-task.log
+   wc -c /tmp/agent-task.log  # quick check: is it growing?
+   ```
+3. **For non-interactive one-shot tasks**, skip tmux entirely and use `run_in_background:true` on the Bash tool (see qodercli section below).
+
+---
+
+## OpenCode (opencode)
+
+OpenCode is typically interactive (TUI), so **run it in tmux**. (Also using the **bash** tool to run tmux)
+
+### Common Commands
+
+- **Start TUI (default)**:
+
+```bash
+tmux new-session -d -s opencode-1 "cd ~/project && opencode"
+```
+
+- **Run with a one-shot message**:
+
+```bash
+tmux new-session -d -s opencode-run-1 "cd ~/project && opencode run 'Build a dark mode toggle'"
+```
+
+- **Choose model / continue session**:
+
+```bash
+# Model format: provider/model
+tmux new-session -d -s opencode-model-1 "cd ~/project && opencode -m zai-coding-plan/glm-4.7 run 'Refactor the auth module'"
+tmux new-session -d -s opencode-continue-1 "cd ~/project && opencode -c"
+tmux new-session -d -s opencode-session-1 "cd ~/project && opencode -s <sessionId>"
+```
+
+### PR Workflow Helpers (optional)
+
+```bash
+# Fetch & checkout PR, then run opencode
+tmux new-session -d -s opencode-pr-130 "cd ~/project && opencode pr 130"
+```
+
+---
+
+## Claude Code
+
+```bash
+# Foreground
+bash command:"cd ~/project && claude --permission-mode bypassPermissions --print 'Your task'"
+
+# Background
+bash run_in_background:true command:"cd ~/project && claude --permission-mode bypassPermissions --print 'Your task'"
+```
+
+---
+
+## iFlow (iflow)
+
+iFlow supports both interactive and non-interactive modes.
+
+### One-shot (non-interactive)
+
+```bash
+bash command:"cd ~/project && iflow -p 'Explain the architecture of this repo and propose 3 refactors'"
+```
+
+### Prompt then stay interactive
+
+```bash
+tmux new-session -d -s iflow-1 "cd ~/project && iflow -i 'Scan the repo and identify risky patterns; then wait for follow-ups'"
+```
+
+### Session controls / limits
+
+```bash
+bash command:"cd ~/project && iflow -c -p 'Summarize changes since last release'"
+bash command:"cd ~/project && iflow --max-turns 25 -p 'Fix failing tests'"
+```
+
+---
+
+## qodercli
+
+qodercli can run as an interactive assistant, or as a non-interactive “print and exit”.
+
+### Interactive
+
+```bash
+tmux new-session -d -s qoder-1 "cd ~/project && qodercli -w ~/project"
+```
+
+### One-shot (non-interactive) — **preferred for delegated tasks**
+
+For one-shot tasks (with `-p`), **prefer direct background bash over tmux**. qodercli's `-p` mode does not need a PTY, and its terminal output is incompatible with `tmux capture-pane` (capture-pane returns empty while qodercli is running). Use `run_in_background:true` on the Bash tool instead:
+
+```bash
+# ✅ Recommended: direct background execution with log file for monitoring
+bash run_in_background:true command:"cd ~/project && qodercli -w ~/project -p 'Your task here' --max-turns 25 2>&1 | tee /tmp/qoder-task.log"
+
+# Monitor progress by reading the log file
+tail -50 /tmp/qoder-task.log
+
+# ❌ Avoid: tmux + capture-pane for qodercli one-shot tasks
+# capture-pane will return empty — qodercli likely uses alternate screen buffer
+# or defers stdout flush, making capture-pane unreliable for progress monitoring.
+```
+
+### Long / non-ASCII prompts
+
+When the prompt is long or contains non-ASCII characters (Chinese, etc.), write it to a temp file first to avoid shell escaping and encoding issues:
+
+```bash
+# 1) Write prompt to file (via the Write tool)
+# 2) Pass it via $(cat ...)
+bash run_in_background:true command:"cd ~/project && qodercli -w ~/project -p \"$(cat /tmp/my-prompt.txt)\" --max-turns 30 2>&1 | tee /tmp/qoder-task.log"
+```
+
+### Machine-readable output
+
+```bash
+bash command:"cd ~/project && qodercli -p 'Summarize src/ responsibilities' -f json"
+```
+
+---
+
+## Parallel Issue Fixing with git worktrees
+
+For fixing multiple issues in parallel, use git worktrees:
+
+```bash
+# 1. Create worktrees for each issue
+git worktree add -b fix/issue-78 /tmp/issue-78 main
+git worktree add -b fix/issue-99 /tmp/issue-99 main
+
+# 2. Launch agents in each (PTY via tmux)
+tmux new-session -d -s issue-78 "cd /tmp/issue-78 && pnpm install && opencode run 'Fix issue #78: <description>. Stop before committing; summarize what changed.'"
+tmux new-session -d -s issue-99 "cd /tmp/issue-99 && pnpm install && iflow -i 'Fix issue #99 from the approved ticket summary. Implement only the in-scope edits; then wait for review.'"
+
+# 3. Monitor progress
+tmux list-sessions
+tmux capture-pane -t issue-78 -p | tail -50
+tmux capture-pane -t issue-99 -p | tail -50
+
+# 4. Create PRs after fixes
+cd /tmp/issue-78 && git push -u origin fix/issue-78
+gh pr create --repo user/repo --head fix/issue-78 --title "fix: ..." --body "..."
+
+# 5. Cleanup
+git worktree remove /tmp/issue-78
+git worktree remove /tmp/issue-99
+```
+
+---
+
+## ⚠️ Rules
+
+1. **Use the right execution mode per agent**:
+   - OpenCode/iFlow: run inside **tmux** for interactivity (PTY)
+   - qodercli one-shot (`-p`): prefer **direct background bash** with `tee` for logging; use tmux only for interactive mode (`-w` without `-p`)
+   - Claude Code: prefer `--print --permission-mode bypassPermissions` (non-interactive)
+2. **Respect tool choice** - if the user asks for a specific agent CLI, use that CLI.
+   - In orchestrator mode: do NOT hand-code patches yourself.
+   - If an agent fails/hangs, respawn it or ask the user for direction; don't silently take over.
+3. **Be patient** - don't kill sessions because they're "slow"
+4. **Monitor smart** - use `tmux capture-pane` first, but if it returns empty after 10s, switch to log file (`tee` output). Don't repeat a failing monitoring method more than twice.
+5. **Parallel is OK** - run multiple background sessions for batch work
+6. **NEVER start agents in ~/** - keep internal docs out of context
+
+---
+
+## ⚠️ Known Pitfalls
+
+### Locale / Encoding
+
+The Bash tool environment may not inherit a UTF-8 locale (e.g., `LANG` may be unset, defaulting to `C`). This causes cosmetic issues (non-ASCII characters appear garbled in `ps aux` output) but **does not affect actual byte-level argument passing** — agents still receive correct UTF-8 content.
+
+If you see garbled characters in process listings, don't assume the agent received bad input. Check the actual output (log file) before concluding there's an encoding problem.
+
+For safety with non-ASCII prompts, write the prompt to a temp file and pass via `$(cat /tmp/prompt.txt)`.
+
+### Scaffolding CLIs (create-next-app, create-vite, etc.)
+
+Scaffolding tools frequently add new interactive prompts across versions. Even with all known flags (e.g. `--typescript --tailwind --eslint`), a new version may introduce an unexpected question that blocks the command.
+
+Always pipe a default answer to handle unexpected prompts:
+```bash
+# ✅ Safe: pipe default answer for unexpected prompts
+echo "no" | npx create-next-app@latest my-app --typescript --tailwind --eslint --app --use-npm
+
+# ❌ Risky: may hang on new interactive prompts
+npx create-next-app@latest my-app --typescript --tailwind --eslint --app --use-npm
+```
+
+---
+
+## Progress Updates (Critical)
+
+When you spawn coding agents in the background, keep the user in the loop.
+
+- Send 1 short message when you start (what's running + where).
+- Then only update again when something changes:
+  - a milestone completes (build finished, tests passed)
+  - the agent asks a question / needs input
+  - you hit an error or need user action
+  - the agent finishes (include what changed + where)
+- If you kill a session, immediately say you killed it and why.
+
+This prevents the user from seeing only "Agent failed before reply" and having no idea what happened.
+

--- a/package.json
+++ b/package.json
@@ -1,23 +1,11 @@
 {
-  "name": "qoder-community",
-  "type": "module",
-  "version": "1.0.0",
-  "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro build",
-    "preview": "astro preview",
-    "astro": "astro",
-    "capture": "node scripts/capture-screenshots.js"
+  "name": "coding-agent",
+  "version": "0.1.0",
+  "description": "Delegate coding tasks to Claude Code, OpenCode, iFlow, or qodercli via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that benefits from agent-driven exploration. NOT for: simple one-liner fixes (just edit), reading a single known file (use file read), thread-bound ACP harness requests in chat, or any work in ~/clawd workspace (never spawn agents here). Claude Code: prefer --print --permission-mode bypassPermissions. OpenCode/iFlow/qodercli: run inside tmux for interactivity (PTY).",
+  "publishConfig": {
+    "registry": "https://contextlab.alibaba-inc.com/skill"
   },
-  "dependencies": {
-    "@astrojs/starlight": "^0.37.1",
-    "astro": "^5.6.1"
-  },
-  "devDependencies": {
-    "playwright": "^1.57.0"
-  },
-  "optionalDependencies": {
-    "sharp": "^0.34.2"
+  "aoneKit": {
+    "generated": true
   }
 }


### PR DESCRIPTION
A skill for delegating coding tasks to Claude Code, OpenCode, iFlow, or qodercli.

## Features
- Support for multiple coding agents (Claude Code, OpenCode, iFlow, qodercli)
- Interactive and non-interactive execution modes
- tmux integration for PTY support
- Parallel issue fixing with git worktrees
- Progress monitoring and logging

## Files Added
- src/content/skills/coding-agent.md (English)
- src/content/skills-zh/coding-agent.md (Chinese)