### PR TITLE
feat: add AI-Shifu Course Creator skill

### DIFF
--- a/src/content/skills/ai-shifu-course-creator.md
+++ b/src/content/skills/ai-shifu-course-creator.md
@@ -8,12 +8,15 @@ githubUrl: https://github.com/ai-shifu/skills/tree/main/skills/ai-shifu-course-c
 docsUrl: https://ai-shifu.cn
 category: productivity
 tags:
+  - ai-shifu
   - ai-course
   - course-production
   - instructional-design
+  - markdownflow
+  - education
+  - ai-tutor
 roles:
   - content
-  - pm
 featured: false
 popular: false
 isOfficial: false
@@ -31,12 +34,14 @@ date: 2026-05-17
 
 ## Core Capabilities
 
-- **Five-phase pipeline**: Segmentation → Orchestration → Generation → Optimization → Deployment
-- **MarkdownFlow (MDF) authoring**: directive-style prompts, prompt-outside / options-inside interaction syntax, mandatory anchoring with downstream effects
-- **Pedagogy-aware**: variable strategy, interaction design, visual-text coordination, language resolution
-- **Standard & fallback modes**: gracefully handles incomplete or low-quality source material
-- **Live deployment**: build, import, and publish directly to the AI-Shifu platform
-- **Creator analytics**: track learner progress, identify stuck lessons, monitor revenue and ratings
+AI-Shifu courses are one-on-one interactive AI tutor sessions — instead of passive video or text, each learner gets an adaptive AI tutor that asks questions, branches based on answers, and personalizes the explanation. This skill helps you produce, deploy, and manage such courses.
+
+- **Two ways to start**: convert your existing material (PPT, Word, PDF, txt, transcripts) into a course, or build a course from just a topic and a description of who you're teaching
+- **Interactive lessons**: script questions, choices, free input, and branching the AI tutor will follow
+- **Per-learner personalization**: adapt explanations, examples, and difficulty to each learner's background and level
+- **Rich content**: combine text, images, and slides within a single lesson
+- **One-click deployment**: publish courses live to the AI-Shifu platform
+- **Course management & analytics**: view your published courses and track learner count, completion rate, stuck lessons, orders, revenue, and ratings
 
 ## Example
 

--- a/src/content/skills/ai-shifu-course-creator.md
+++ b/src/content/skills/ai-shifu-course-creator.md
@@ -1,0 +1,64 @@
+---
+name: ai-shifu-course-creator
+title: AI-Shifu Course Production Expert
+description: Based on your teaching needs and source materials (PPT, Word, PDF, txt, etc.), helps you quickly build a one-on-one interactive AI course on the AI-Shifu platform
+source: community
+author: heshaofu
+githubUrl: https://github.com/ai-shifu/skills/tree/main/skills/ai-shifu-course-creator
+docsUrl: https://ai-shifu.cn
+category: productivity
+tags:
+  - ai-course
+  - course-production
+  - instructional-design
+roles:
+  - content
+  - pm
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  git clone https://github.com/ai-shifu/skills
+  cp -r skills/skills/ai-shifu-course-creator ~/.qoder/skills/
+date: 2026-05-17
+---
+
+## Use Cases
+
+- Build an AI-Shifu course from scratch on a given topic, personalized for learners from different backgrounds
+- Turn uploaded source material (PPT, Word, PDF, txt) into an AI-Shifu course with text and images
+- View and manage your existing courses on the AI-Shifu platform
+
+## Core Capabilities
+
+- **Five-phase pipeline**: Segmentation → Orchestration → Generation → Optimization → Deployment
+- **MarkdownFlow (MDF) authoring**: directive-style prompts, prompt-outside / options-inside interaction syntax, mandatory anchoring with downstream effects
+- **Pedagogy-aware**: variable strategy, interaction design, visual-text coordination, language resolution
+- **Standard & fallback modes**: gracefully handles incomplete or low-quality source material
+- **Live deployment**: build, import, and publish directly to the AI-Shifu platform
+- **Creator analytics**: track learner progress, identify stuck lessons, monitor revenue and ratings
+
+## Example
+
+```
+Build an AI-Shifu course on the topic of "Why should I learn AI".
+Keep it within 4 sections, and personalize the teaching for users
+from different backgrounds. The teaching should combine PPT slides with text.
+```
+
+```
+Help me turn this uploaded material into an AI-Shifu course.
+The lessons should be illustrated with both text and images.
+```
+
+```
+Help me check my courses on the AI-Shifu platform.
+```
+
+## Notes
+
+- Both Teaching Prompts and Course Prompts are written in MarkdownFlow (MDF)
+- Output language is resolved before any prompt content — examples in references are English-only for canonical illustration
+- Keep author-side meta labels (e.g. "Knowledge Block 1/2/3", "Lesson Objective") out of learner-facing output
+- Use natural-language image instructions; do not inline SVG/HTML/Mermaid markup unless the user requests it
+- Companion skill in the same repo: `course-direction-advisor` (course topic selection and market-fit decisions)


### PR DESCRIPTION
## Summary

- Add the `ai-shifu-course-creator` skill from [ai-shifu/skills](https://github.com/ai-shifu/skills/tree/main/skills/ai-shifu-course-creator) to the community catalog
- AI-Shifu courses are one-on-one interactive AI tutor sessions; this skill helps users turn source material (PPT, Word, PDF, txt, transcripts) into such courses, or build one from just a topic, and then deploy and manage them on the AI-Shifu platform
- Single new file at `src/content/skills/ai-shifu-course-creator.md` (English only — Chinese routes auto-fall back to the English body per existing `src/pages/zh/skills/[slug].astro` logic)

## Test plan

- [x] `npm run build` passes (schema validation, 135 pages built)
- [x] English detail page renders at `/skills/ai-shifu-course-creator/`
- [x] Chinese detail page renders at `/zh/skills/ai-shifu-course-creator/` (falls back to English body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)