### PR TITLE
feat: add investoday-finance-data skill

### DIFF
--- a/src/content/skills-zh/investoday-finance-data.md
+++ b/src/content/skills-zh/investoday-finance-data.md
@@ -1,0 +1,34 @@
+---
+slug: investoday-finance-data
+---
+
+## 使用场景
+
+- 查询 A 股、港股、指数、基金、ETF 的近期走势和市场表现
+- 拉取公司基本资料、财务报表、估值指标、分红等结构化数据
+- 查看公告、研报、机构观点、新闻和市场热点
+- 浏览板块、主题、产业链以及宏观经济数据
+- 为后续对比、分析和研究导出结构化金融数据
+
+## 示例
+
+```bash
+# 首次使用前初始化 CLI 本地运行环境
+investoday-api init
+
+# 浏览分组和叶子菜单
+investoday-api list
+investoday-api list 沪深京数据/公司行为/基本信息
+
+# 按关键词搜索接口
+investoday-api search-api query=股票,基本面分析
+
+# 明确接口后直接取数
+investoday-api stock/basic-info stockCode=600519
+```
+
+## 注意事项
+
+- 这个 GitHub 仓库里不只有 skill，还包含 `create/`、`package/`、`tests/` 等工程化内容；安装到 Qoder 时只应复制 `skills/` 子目录。
+- 除了复制 skill，还需要安装 `@investoday/investoday-api`，并在首次使用前执行 `investoday-api init`。
+- 当接口路径不明确时，优先使用 `investoday-api list` 和 `investoday-api search-api`，不要手写 HTTP 请求替代 CLI。

--- a/src/content/skills/investoday-finance-data.md
+++ b/src/content/skills/investoday-finance-data.md
@@ -1,0 +1,63 @@
+---
+name: investoday-finance-data
+title: Investoday Financial Data
+description: Fetch Chinese financial market and research data across A-shares, Hong Kong stocks, funds, indices, financial statements, announcements, research reports, and macro datasets through a CLI-backed skill.
+source: community
+author: Investoday Data
+githubUrl: https://github.com/investoday-data/investoday-finance-data
+docsUrl: https://github.com/investoday-data/investoday-finance-data#readme
+category: data
+tags:
+  - finance
+  - market-data
+  - a-share
+  - hk-stock
+  - fund
+  - macro
+  - research
+roles:
+  - finance
+  - data-analyst
+  - developer
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  git clone https://github.com/investoday-data/investoday-finance-data
+  mkdir -p ~/.qoder/skills/investoday-finance-data
+  cp -r investoday-finance-data/skills/. ~/.qoder/skills/investoday-finance-data/
+  npm install -g @investoday/investoday-api
+date: 2026-05-21
+lastUpdated: 2026-05-21
+---
+
+## Use Cases
+
+- Check recent price action for A-shares, Hong Kong stocks, indices, funds, and ETFs
+- Pull company profile, financial statements, valuation metrics, and dividend history
+- Review announcements, research reports, institutional views, and market news
+- Explore sectors, themes, industry chains, and macroeconomic datasets
+- Export structured market data for downstream analysis and comparison
+
+## Example
+
+```bash
+# Initialize the local CLI runtime before first use
+investoday-api init
+
+# Browse available groups and leaf categories
+investoday-api list
+investoday-api list 沪深京数据/公司行为/基本信息
+
+# Search APIs by keyword
+investoday-api search-api query=股票,基本面分析
+
+# Fetch data directly once the endpoint is known
+investoday-api stock/basic-info stockCode=600519
+```
+
+## Notes
+
+- This repository contains engineering assets beyond the skill itself. Only the `skills/` subdirectory should be copied into `~/.qoder/skills/investoday-finance-data/`.
+- Install the companion CLI package `@investoday/investoday-api` and run `investoday-api init` before the first query.
+- Prefer `investoday-api list` and `investoday-api search-api` when the exact endpoint is not yet clear.

--- a/src/i18n/skills-translations.ts
+++ b/src/i18n/skills-translations.ts
@@ -145,6 +145,11 @@ export const skillsTranslations: Record<string, SkillTranslation> = {
     zhTitle: 'AWS 开发技能',
     zhDescription: 'AWS 开发和基础设施自动化，包括 CDK、Lambda、S3 和其他服务',
   },
+  'investoday-finance-data': {
+    zhName: '今日投资金融数据',
+    zhTitle: '今日投资金融数据',
+    zhDescription: '通过 CLI 获取 A 股、港股、基金、指数、财务、公告、研报和宏观等中国市场结构化金融数据',
+  },
   'dev-agent-skills': {
     zhName: 'Git & GitHub 工作流',
     zhTitle: 'Git & GitHub 工作流',


### PR DESCRIPTION
## Summary
- add the `investoday-finance-data` community skill entry in English
- add the matching Chinese content page
- add Chinese list-card translation metadata for this skill

## Why
`investoday-finance-data` is a finance/data skill whose repository contains both the runtime skill and additional engineering assets. This PR documents the skill with a custom install command that copies only the `skills/` subdirectory and installs the companion CLI.

## Validation
- `git diff --check`
- frontmatter/content self-check for both new Markdown files
- `npm run build` could not be executed because the current upstream `package.json` in `Qoder-AI/qoder-community@main` does not define a `build` script and does not declare the Astro dependencies referenced by the repository and CONTRIBUTING guide
