### PR TITLE
feat: add iflow-search community skill

### DIFF
--- a/src/content/skills-zh/iflow-search.md
+++ b/src/content/skills-zh/iflow-search.md
@@ -1,0 +1,54 @@
+---
+slug: iflow-search
+---
+
+## 使用场景
+
+- 在模型训练截止之后做实时网页检索
+- 按关键词搜索图片（参考图、截图、商品图）
+- 把已知 URL 抓取并清洗为 markdown，供 agent 总结
+- 串起 "搜索 → 选链接 → 抓正文" 的研究流程
+
+## 核心能力
+
+- **Web Search** —— 通过 iFlow 网页索引按关键词检索
+- **Image Search** —— 图片结果，带 refUrl 和标题
+- **Web Fetch** —— 抓取 URL 并返回清洗后的 markdown 正文
+
+## 示例
+
+在启动 Qoder 之前先在 shell 里导出 `IFLOW_API_KEY`，agent 即可把检索类任务交给这个 skill：
+
+```
+帮我找最近关于 LLM agent benchmark 的报道，再抓取前三篇正文给我做总结。
+```
+
+Skill 内部会按 "web search → 选链接 → web fetch" 串起来。
+
+## API Key 设置
+
+1. 在 https://platform.iflow.cn/profile?tab=apiKey 申请 API Key
+2. 在启动 Qoder **之前**导出环境变量。
+
+zsh：
+
+```bash
+echo 'export IFLOW_API_KEY="YOUR_IFLOW_API_KEY"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+bash：
+
+```bash
+echo 'export IFLOW_API_KEY="YOUR_IFLOW_API_KEY"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+不要把 key 作为 CLI 参数传，也不要 commit 进任何文件。
+
+## 注意事项
+
+- Skill 源码：https://github.com/iflow-ai/iflow-skills/tree/main/skills/iflow-search
+- Skill 安装指南：https://platform.iflow.cn/docs/skill
+- iFlow Search API 文档：https://platform.iflow.cn/docs/
+- `IFLOW_API_KEY` 必须在启动 Qoder 的同一个 shell 里设置好。

--- a/src/content/skills/iflow-search.md
+++ b/src/content/skills/iflow-search.md
@@ -1,0 +1,78 @@
+---
+name: iflow-search
+title: iFlow Search
+description: Web search, image search, and web fetch via the iFlow Search API.
+source: community
+author: iFlow Open Platform
+githubUrl: https://github.com/iflow-ai/iflow-skills/tree/main/skills/iflow-search
+docsUrl: https://platform.iflow.cn/docs
+category: data
+tags:
+  - iflow
+  - web-search
+  - image-search
+  - web-fetch
+  - api
+roles:
+  - developer
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  git clone https://github.com/iflow-ai/iflow-skills.git /tmp/iflow-skills
+  mkdir -p ~/.qoder/skills
+  cp -r /tmp/iflow-skills/skills/iflow-search ~/.qoder/skills/iflow-search
+  rm -rf /tmp/iflow-skills
+date: 2026-05-22
+---
+
+## Use Cases
+
+- Pull fresh web results for topics past the model's training cutoff
+- Search for images by keyword (references, screenshots, product shots)
+- Read a known URL as cleaned-up markdown for downstream summarization
+- Chain search → pick links → fetch each, to assemble a small research dossier
+
+## Core Capabilities
+
+- **Web Search** — keyword search via the iFlow web index
+- **Image Search** — image results with reference URLs and titles
+- **Web Fetch** — fetch a URL and return cleaned markdown content
+
+## Example
+
+After `IFLOW_API_KEY` is exported in the shell that launches Qoder, the agent can route research tasks to this skill:
+
+```
+Find recent reporting on LLM agent benchmarks, then fetch the top three article texts so I can summarize them.
+```
+
+The skill chains `web search → choose links → web fetch` end to end.
+
+## API Key Setup
+
+1. Create a key at https://platform.iflow.cn/profile?tab=apiKey
+2. Export it in the shell **before** starting Qoder.
+
+For zsh:
+
+```bash
+echo 'export IFLOW_API_KEY="YOUR_IFLOW_API_KEY"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+For bash:
+
+```bash
+echo 'export IFLOW_API_KEY="YOUR_IFLOW_API_KEY"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Do not pass the key as a CLI flag and do not commit it to any file.
+
+## Notes
+
+- Skill source: https://github.com/iflow-ai/iflow-skills/tree/main/skills/iflow-search
+- Skill install guide: https://platform.iflow.cn/docs/skill
+- iFlow Search API docs: https://platform.iflow.cn/docs/
+- `IFLOW_API_KEY` must be set in the same shell that launches Qoder.

--- a/src/i18n/skills-translations.ts
+++ b/src/i18n/skills-translations.ts
@@ -251,6 +251,11 @@ export const skillsTranslations: Record<string, SkillTranslation> = {
     zhTitle: '向量搜索',
     zhDescription: '使用向量搜索进行语义文件查找和相似度匹配',
   },
+  'iflow-search': {
+    // No zhName - keep brand slug 'iflow-search'
+    zhTitle: 'iFlow 心流搜索',
+    zhDescription: '通过 iFlow Search API 提供网页搜索、图片搜索和网页抓取能力的社区 skill。',
+  },
 
   // === Security Skills ===
   'building-secure-contracts': {


### PR DESCRIPTION
## Summary
- add the `iflow-search` community skill entry in English
- add the matching Chinese content page
- add Chinese title/description metadata for this skill

## Why
`iflow-search` is a community skill that wraps the iFlow Search API for use inside Qoder. It provides web search, image search, and web fetch capabilities through the existing Qoder Skills mechanism.

This PR documents the skill, references its upstream source at https://github.com/iflow-ai/iflow-skills/tree/main/skills/iflow-search, and gives users a clean install command plus an `IFLOW_API_KEY` environment-variable setup. The PR contains no real API key value — only the `YOUR_IFLOW_API_KEY` placeholder.

## Validation
- Frontmatter matches the Skills schema used in `src/content.config.ts`:
  - `category: data`
  - `source: community`
  - `isOfficial: false`
  - `roles: [developer]`
- Code fences in both English and Chinese files are balanced.
- The change is limited to three files:
  - English skill entry
  - Chinese skill entry
  - one translation metadata entry

I also validated these entries locally with the site build pipeline after working around pre-existing build issues on the current `main` branch. The generated pages included:

- `dist/skills/iflow-search/index.html`
- `dist/zh/skills/iflow-search/index.html`

`npm run preview` returned HTTP 200 for both routes.

## Notes for reviewers
- No real API key is included anywhere.
- The only `IFLOW_API_KEY` occurrences are the environment-variable name plus the `YOUR_IFLOW_API_KEY` placeholder.
- The Chinese content follows the existing slug-only Chinese frontmatter convention used by other community skill entries.