### PR TITLE
feat(skills): add Jinshuju (金数据) skill

### DIFF
--- a/src/content/skills-zh/jinshuju.md
+++ b/src/content/skills-zh/jinshuju.md
@@ -1,0 +1,30 @@
+---
+slug: jinshuju
+---
+
+## 使用场景
+
+- 创建、复制、移动、编辑表单并调整主题——支持 39 种字段类型（含矩阵、商品、公式、关联表单、预约等），头图可由 AI 根据表单内容自动生成
+- 查询、新增、批量修改与删除表单数据，支持字段值条件下推过滤（等值 / 区间 / 模糊 / 集合等）与游标分页
+- 查看当前用户、企业套餐与用量额度，列出团队成员
+- 查询电子发票与付款记录
+
+## 示例
+
+```text
+用户：帮我建一个"2026 春季产品发布会"报名表，要姓名、手机号、公司、职位
+助手：（调用 create_form 创建表单并返回链接与 form_token）
+
+用户：统计一下本月报名里手机号以 138 开头的有几条
+助手：（list_entries 用 filters 把 like / created_at 条件下推到数据库，分页拉回）
+
+用户：把这些人的"跟进状态"全部改成"已联系"
+助手：（先展示命中记录并二次确认，确认后逐条调用 update_entry）
+```
+
+## 注意事项
+
+- 本 Skill 基于金数据 MCP Server（`https://jinshuju.net/mcp`）。安装 Skill 后需在 AI 客户端配置 MCP 连接器——推荐 OAuth 2.0 授权，也可用 API Key / Secret 走 HTTP Basic。配置方式见 [金数据 MCP 文档](https://open.jinshuju.net/mcp/)。
+- 安装到 Qoder 时只需复制仓库的 `skills/jinshuju/` 子目录到 `~/.qoder/skills/jinshuju/`。
+- entry 数据的键必须是字段的 `api_code`（不是中文 label），选项字段要传选项的 `api_code`（不是显示文案），否则服务端会静默丢弃或返回 400。
+- `update_entry` 默认走 PATCH（`is_put=false`）；只有在确认整条替换时才设 `is_put=true`，因为它会清空所有未提供的字段。

--- a/src/content/skills/jinshuju.md
+++ b/src/content/skills/jinshuju.md
@@ -1,0 +1,56 @@
+---
+name: jinshuju
+title: Jinshuju (金数据)
+description: Build and edit forms, query and bulk-update entries, and check account, billing, and team data on Jinshuju (金数据) through its MCP server using natural language.
+source: community
+author: Jinshuju
+githubUrl: https://github.com/jinshuju/jinshuju-skill
+docsUrl: https://open.jinshuju.net/mcp/
+category: productivity
+tags:
+  - forms
+  - data-collection
+  - survey
+  - mcp
+  - 金数据
+roles:
+  - developer
+  - data-analyst
+  - pm
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  git clone https://github.com/jinshuju/jinshuju-skill
+  mkdir -p ~/.qoder/skills/jinshuju
+  cp -r jinshuju-skill/skills/jinshuju/. ~/.qoder/skills/jinshuju/
+date: 2026-05-29
+lastUpdated: 2026-05-29
+---
+
+## Use Cases
+
+- Create, copy, move, or edit forms and adjust themes — 39 field types including matrix, product, formula, linked-form, and appointment fields, with AI-generated header images
+- Query, create, bulk-update, and delete form entries with server-side filter push-down (equals / range / fuzzy / set conditions) and cursor pagination
+- Check the current user, enterprise plan and usage quota, and list team members
+- Look up electronic invoices and payment history
+
+## Example
+
+```text
+User: Build a "2026 Spring Product Launch" registration form with name, mobile, company, and title.
+Assistant: (calls create_form, returns the form link and form_token)
+
+User: Count this month's registrations whose mobile number starts with 138.
+Assistant: (list_entries pushes the like / created_at filters down to the database, then paginates)
+
+User: Set "follow-up status" to "Contacted" for all of those people.
+Assistant: (shows matched entries, asks for confirmation, then calls update_entry one by one)
+```
+
+## Notes
+
+- This skill is powered by the Jinshuju MCP server at `https://jinshuju.net/mcp`. After installing the skill, configure the MCP connector in your AI client — OAuth 2.0 is recommended, or HTTP Basic with an API Key / Secret. See the [MCP docs](https://open.jinshuju.net/mcp/) for details.
+- Only the `skills/jinshuju/` subdirectory of the repository should be copied into `~/.qoder/skills/jinshuju/`.
+- Entry payload keys must be the field `api_code` (not the Chinese label), and option fields take the option's `api_code` (not the display text) — otherwise the server silently drops the value or returns a 400.
+- `update_entry` defaults to PATCH (`is_put=false`); only set `is_put=true` for a confirmed full-record replacement, as it clears any field you omit.

--- a/src/i18n/skills-translations.ts
+++ b/src/i18n/skills-translations.ts
@@ -355,6 +355,11 @@ export const skillsTranslations: Record<string, SkillTranslation> = {
     zhTitle: 'Things 3 任务管理',
     zhDescription: 'Things 3 任务管理集成，用于个人待办事项和项目管理',
   },
+  'jinshuju': {
+    zhName: '金数据',
+    zhTitle: '金数据',
+    zhDescription: '通过金数据 MCP 用自然语言搭建与编辑表单、查询与批量修改数据，以及查看账户、账单和团队信息',
+  },
 
   // === Meta Skills ===
   'skill-creator': {


### PR DESCRIPTION
Add the Jinshuju form-and-data MCP skill:
- src/content/skills/jinshuju.md — English entry with full metadata
- src/content/skills-zh/jinshuju.md — Simplified Chinese translated body (slug-only)
- src/i18n/skills-translations.ts — zhName/zhTitle/zhDescription so the Chinese marketplace shows the localized name and description

Verified with astro build (using the preprod package.json, since main's package.json is an unrelated placeholder): both /skills/jinshuju and /zh/skills/jinshuju render with correct localized title, description, and body.