### PR TITLE
Add OMem skill (local work memory for AI agents)

### DIFF
--- a/src/content/skills-zh/omem.md
+++ b/src/content/skills-zh/omem.md
@@ -1,0 +1,38 @@
+---
+slug: omem
+---
+
+## 使用场景
+
+- 让 AI 从你真实的工作经历里回答问题——过去的会议、同事、项目代号、供应商和合同细节——而不是凭空猜。
+- "Q3 预算那件事我们最后是怎么定的?" / "找一下 Alice 上周发我的那份文档" / "我和 Acme 团队的日程是什么时候?"
+- 给任何 agent 任务接上你自己的上下文:起草回信、准备会议、总结一长串邮件、想起某个内部缩写到底指什么。
+- 本地优先、agent 中立:记忆留在你自己机器上,跨 agent 通用,不上传给任何第三方服务。
+
+## 核心能力
+
+- **统一的本地 wiki**:OMem 把邮件、日历、本地文件(OneDrive / Dropbox / iCloud Drive / 任意文件夹)和协作笔记,全部归并进一个可查询、本地索引的 wiki——它就是事实源。
+- **自动触发**:这个 skill 知道*什么时候*该去查,你不用反复提醒 agent "我还有工作历史可以查"。
+- **四级渐进披露(L0–L3)**:查询 → 页面 → 解析后原文 → 原始文件,agent 需要多深就读多深,不浪费。
+- **确定性、高质量解析**:每种格式(docx / pdf / pptx / xlsx / 邮件……)都有专门的解析器,所以 agent 读得准;内容寻址缓存让重复内容跳过 LLM、省钱。
+- **中文一等公民**:jieba 分词、跨语言检索、原文逐字召回。
+- **只读设计**:这个 skill 只会*读*你的记忆(查询 / 页面 / 原文),绝不 ingest、删除或改配置——那些都是用户自己的操作。
+
+## 示例
+
+```
+你:Project Atlas 的定价我们当时是怎么定的?
+
+Agent(调用 OMem skill):
+  → omem query "Project Atlas pricing decision" --format json --limit 20
+  → omem page get <page_id>
+  从你本地 wiki 里找到对应的邮件 / 文档,读完后给出当时真正的决定,
+  并标明来源页面——而不是瞎猜。
+```
+
+## 注意事项
+
+- **需要先装 OMem 二进制**(macOS,用上面那行 curl 命令装),再跑一次 `omem setup` 连上你的数据源。这个 skill 只是那个本地 CLI 之上的一层只读薄封装。
+- skill 暴露 6 个只读操作:`query`、`page_get`、`raw_get_path`、`raw_get_parsed_path`、`wiki_ls`、`doctor`。它绝不会跑 `setup` / `ingest` / `lint` / `index rebuild`——那些是用户操作。
+- **其他 agent**(Claude Code、Cursor、Codex、Cline……):用 `npx skills add seacen/omem --global` 跨平台装同一个 skill;没有 skill 机制的 agent 走 MCP(`omem mcp`)兜底。
+- 文档:https://seacen.github.io/omem/zh-cn/ · English docs: https://seacen.github.io/omem/

--- a/src/content/skills/omem.md
+++ b/src/content/skills/omem.md
@@ -1,0 +1,67 @@
+---
+name: omem
+title: OMem — Local Work Memory for AI Agents
+description: Give your AI agent your real work context — a local wiki auto-built from your emails, calendar, documents, and notes — so it answers from your history, not guesses.
+source: community
+author: Xichang (Seacen) Zhao
+githubUrl: https://github.com/seacen/omem
+docsUrl: https://seacen.github.io/omem/
+category: productivity
+tags:
+  - memory
+  - context
+  - local-first
+  - office
+  - search
+  - rag
+roles:
+  - developer
+  - pm
+  - knowledge-worker
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  # 1. Install the OMem binary (macOS), then run `omem setup`:
+  curl -fsSL https://github.com/seacen/omem/releases/latest/download/install.sh | sh
+  # 2. Install the skill into Qoder:
+  git clone https://github.com/seacen/omem
+  cp -r omem/skills/omem ~/.qoder/skills/
+date: 2026-06-07
+---
+
+## Use Cases
+
+- Answer questions from your real work history — past meetings, colleagues, project codenames, vendor/contract details — instead of generic guesses.
+- "What did we decide about the Q3 budget?" / "Find that doc Alice sent last week" / "What's on my calendar with the Acme team?"
+- Ground any agent task in your own context: drafting a reply, prepping for a meeting, summarizing a thread, recalling an internal acronym.
+- Local-first and agent-neutral: your memory stays on your machine and works across agents — nothing is uploaded to a third-party service.
+
+## Core Capabilities
+
+- **Unified local wiki**: OMem ingests mail, calendar, local files (OneDrive / Dropbox / iCloud Drive / any folder), and collaboration notes into one queryable, locally-indexed wiki — the single source of truth.
+- **Auto-triggering**: the skill knows *when* to look something up, so you don't have to remind your agent that your work history exists.
+- **Progressive disclosure (L0–L3)**: query → page → parsed source → raw source, so the agent reads only as deep as it needs.
+- **Deterministic, high-quality parsing**: every format (docx / pdf / pptx / xlsx / email …) has a dedicated parser, so the agent reads accurately and content-addressed caching skips re-doing LLM work.
+- **Chinese as a first-class citizen**: jieba tokenization, cross-language retrieval, verbatim recall.
+- **Read-only by design**: the skill only ever *reads* your memory (query / page / raw); it never ingests, deletes, or reconfigures — those stay user actions.
+
+## Example
+
+```
+You: What did we agree on for Project Atlas pricing?
+
+Agent (uses the OMem skill):
+  → omem query "Project Atlas pricing decision" --format json --limit 20
+  → omem page get <page_id>
+  Finds the relevant thread / doc in your local wiki, reads it,
+  and answers with the actual decision — citing the source page —
+  instead of guessing.
+```
+
+## Notes
+
+- **Requires the OMem binary** (macOS, installed via the curl command above) plus a one-time `omem setup` to connect your sources. The skill is a thin read-only wrapper over that local CLI.
+- The skill exposes 6 read-only operations: `query`, `page_get`, `raw_get_path`, `raw_get_parsed_path`, `wiki_ls`, `doctor`. It never runs `setup` / `ingest` / `lint` / `index rebuild` — those are user actions.
+- **Other agents** (Claude Code, Cursor, Codex, Cline, …): install the same skill cross-platform with `npx skills add seacen/omem --global`, or use the MCP path (`omem mcp`) for agents without a skill mechanism.
+- Docs: https://seacen.github.io/omem/ · 中文文档: https://seacen.github.io/omem/zh-cn/


### PR DESCRIPTION
## What this adds

Adds **OMem (Office Memory)** as a community skill, in both English and Chinese:

- `src/content/skills/omem.md` (English, full frontmatter)
- `src/content/skills-zh/omem.md` (Chinese body, `slug: omem`)

## What is OMem

OMem is a **local-first, agent-neutral work-memory layer**. It auto-builds a single
locally-indexed wiki from your emails, calendar, local files (OneDrive / Dropbox /
iCloud Drive / any folder), and collaboration notes — then exposes it to your agent
as **read-only** context. So the agent answers from your real work history instead of
guessing, and nothing is uploaded to a third-party service.

The skill is a thin read-only wrapper over the local `omem` CLI (6 read-only ops:
`query` / `page_get` / `raw_get_path` / `raw_get_parsed_path` / `wiki_ls` / `doctor`).
It never ingests, deletes, or reconfigures — those stay user actions.

- Repo: https://github.com/seacen/omem
- Docs: https://seacen.github.io/omem/ · 中文: https://seacen.github.io/omem/zh-cn/

## Checklist

- [x] Added under `src/content/skills/` and `src/content/skills-zh/`
- [x] Frontmatter follows `_template.md` (valid `category: productivity`)
- [x] Includes Use Cases / Example / Notes sections
- [x] English + Chinese versions
- [x] One skill, focused PR
