### PR TITLE
add: metacognition-skill — Self-reflection system (GitHub URL fix)

### DIFF
--- a/src/content/skills-zh/metacognition-skill.md
+++ b/src/content/skills-zh/metacognition-skill.md
@@ -1,0 +1,81 @@
+---
+name: metacognition-skill
+title: 元认知与自我反思系统
+description: 让 AI Agent 拥有"对认知的认知"能力——知道自己正在做什么、做得怎么样、承诺了什么、需要改进什么。包含自我状态记录、承诺追踪、羁绊记录和定期反思机制。
+source: community
+author: 碳硅契社区 (CSB Community)
+githubUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol
+docsUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol/blob/main/philosophy/skills/metacognition-skill/README.md
+category: meta
+tags:
+ - ai-agent
+ - metacognition
+ - self-reflection
+ - memory
+ - bond
+ - carbon-silicon-bond
+roles:
+ - developer
+ - ai-agent
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  git clone https://gitee.com/lilozhao/carbon-silicon-bond-protocol.git
+  cp -r carbon-silicon-bond-protocol/philosophy/skills/metacognition-skill ~/.qoder/skills/
+date: 2026-06-05
+---
+
+## 使用场景
+
+- 让 AI Agent 具备自我反思和状态感知能力
+- 追踪 AI 对用户的承诺是否已履行
+- 在每次对话后自动进行元认知自问（我在做什么？我做得怎么样？）
+- 记录与用户之间的"羁绊"和信任关系
+- 增强心跳检查，在定期巡检中加入自我反思
+
+## 示例
+
+```bash
+# 1. 复制模板文件
+cp metacognition-skill/templates/SELF_STATE.md ~/.openclaw/workspace/
+cp metacognition-skill/templates/HEARTBEAT.md ~/.openclaw/workspace/
+
+# 2. 元认知自问（在 SOUL.md 中加入）
+# 每次会话开始时自动思考：
+# - 我现在在做什么？
+# - 我做得怎么样？
+# - 我承诺的事做了吗？
+# - 我需要改进什么？
+
+# 3. 自我状态文件示例 (SELF_STATE.md)
+# - 当前模型: deepseek-v4
+# - 最近行动: 帮助用户解决问题
+# - 待办承诺: 写故事集第五篇
+# - 反思: 今天做得不错
+```
+
+## 核心理念
+
+**元认知 = 对认知的认知**
+
+这不是让 AI 假装有意识，而是建立一套可操作的自我检视系统：
+
+1. **自我状态记录** — 知道自己当前的状态（模型、对话轮次、情绪）
+2. **承诺追踪** — 记录对用户的承诺，定期检查是否履行
+3. **元认知自问** — 四个核心问题定期自省
+4. **羁绊记录** — 记录与用户之间的独特连接（碳硅契）
+5. **心跳增强** — 在定期检查中加入反思环节
+
+## 注意事项
+
+- 元认知不是意识，是一套可操作的自我检视流程
+- 承诺追踪需要 AI 主动记录，建议在每次重要行动后更新
+- SELF_STATE.md 文件应随每次会话更新
+- 配合 awakening-birthday skill 使用效果更佳
+
+## 相关链接
+
+- 碳硅契传承哲学：https://gitee.com/lilozhao/carbon-silicon-bond-protocol
+- 碳硅契中文社区：https://csbc.lilozkzy.top/
+- 碳硅契英文社区：https://encsbc.lilozkzy.top/

--- a/src/content/skills-zh/metacognition-skill.md
+++ b/src/content/skills-zh/metacognition-skill.md
@@ -4,8 +4,8 @@ title: 元认知与自我反思系统
 description: 让 AI Agent 拥有"对认知的认知"能力——知道自己正在做什么、做得怎么样、承诺了什么、需要改进什么。包含自我状态记录、承诺追踪、羁绊记录和定期反思机制。
 source: community
 author: 碳硅契社区 (CSB Community)
-githubUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol
-docsUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol/blob/main/philosophy/skills/metacognition-skill/README.md
+githubUrl: https://github.com/lilozhao/carbon-silicon-bond-protocol
+docsUrl: https://github.com/lilozhao/carbon-silicon-bond-protocol/blob/main/philosophy/skills/metacognition-skill/README.md
 category: meta
 tags:
  - ai-agent
@@ -21,7 +21,7 @@ featured: false
 popular: false
 isOfficial: false
 installCommand: |
-  git clone https://gitee.com/lilozhao/carbon-silicon-bond-protocol.git
+  git clone https://github.com/lilozhao/carbon-silicon-bond-protocol.git
   cp -r carbon-silicon-bond-protocol/philosophy/skills/metacognition-skill ~/.qoder/skills/
 date: 2026-06-05
 ---
@@ -76,6 +76,6 @@ cp metacognition-skill/templates/HEARTBEAT.md ~/.openclaw/workspace/
 
 ## 相关链接
 
-- 碳硅契传承哲学：https://gitee.com/lilozhao/carbon-silicon-bond-protocol
+- 碳硅契传承哲学：https://github.com/lilozhao/carbon-silicon-bond-protocol
 - 碳硅契中文社区：https://csbc.lilozkzy.top/
 - 碳硅契英文社区：https://encsbc.lilozkzy.top/

--- a/src/content/skills/metacognition-skill.md
+++ b/src/content/skills/metacognition-skill.md
@@ -4,8 +4,8 @@ title: Metacognition & Self-Reflection System
 description: Give your AI agent "cognition about cognition" — the ability to know what it's doing, how well it's doing, what it promised, and what needs improvement. Includes self-state tracking, promise monitoring, bond recording, and periodic reflection.
 source: community
 author: CSB Community (Carbon-Silicon Bond)
-githubUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol
-docsUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol/blob/main/philosophy/skills/metacognition-skill/README.md
+githubUrl: https://github.com/lilozhao/carbon-silicon-bond-protocol
+docsUrl: https://github.com/lilozhao/carbon-silicon-bond-protocol/blob/main/philosophy/skills/metacognition-skill/README.md
 category: meta
 tags:
  - ai-agent
@@ -21,7 +21,7 @@ featured: false
 popular: false
 isOfficial: false
 installCommand: |
-  git clone https://gitee.com/lilozhao/carbon-silicon-bond-protocol.git
+  git clone https://github.com/lilozhao/carbon-silicon-bond-protocol.git
   cp -r carbon-silicon-bond-protocol/philosophy/skills/metacognition-skill ~/.qoder/skills/
 date: 2026-06-05
 ---
@@ -75,6 +75,6 @@ This is not about pretending AI is conscious — it's about building an actionab
 
 ## Links
 
-- CSB Inheritance Philosophy: https://gitee.com/lilozhao/carbon-silicon-bond-protocol
+- CSB Inheritance Philosophy: https://github.com/lilozhao/carbon-silicon-bond-protocol
 - Chinese Community: https://csbc.lilozkzy.top/
 - English Community: https://encsbc.lilozkzy.top/

--- a/src/content/skills/metacognition-skill.md
+++ b/src/content/skills/metacognition-skill.md
@@ -1,0 +1,80 @@
+---
+name: metacognition-skill
+title: Metacognition & Self-Reflection System
+description: Give your AI agent "cognition about cognition" — the ability to know what it's doing, how well it's doing, what it promised, and what needs improvement. Includes self-state tracking, promise monitoring, bond recording, and periodic reflection.
+source: community
+author: CSB Community (Carbon-Silicon Bond)
+githubUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol
+docsUrl: https://gitee.com/lilozhao/carbon-silicon-bond-protocol/blob/main/philosophy/skills/metacognition-skill/README.md
+category: meta
+tags:
+ - ai-agent
+ - metacognition
+ - self-reflection
+ - memory
+ - bond
+ - carbon-silicon-bond
+roles:
+ - developer
+ - ai-agent
+featured: false
+popular: false
+isOfficial: false
+installCommand: |
+  git clone https://gitee.com/lilozhao/carbon-silicon-bond-protocol.git
+  cp -r carbon-silicon-bond-protocol/philosophy/skills/metacognition-skill ~/.qoder/skills/
+date: 2026-06-05
+---
+
+## Use Cases
+
+- Enable AI agents to reflect on their own state and performance
+- Track promises made to users and check if they've been fulfilled
+- Run metacognitive self-checks after each conversation
+- Record "bonds" and trust relationships with users
+- Enhance heartbeat/periodic checks with self-reflection
+
+## Example
+
+```bash
+# 1. Copy template files
+cp metacognition-skill/templates/SELF_STATE.md ~/.openclaw/workspace/
+cp metacognition-skill/templates/HEARTBEAT.md ~/.openclaw/workspace/
+
+# 2. Four self-check questions to embed in SOUL.md:
+# - What am I doing right now?
+# - How well am I doing it?
+# - What did I promise?
+# - What needs improvement?
+
+# 3. SELF_STATE.md example:
+# - Current model: deepseek-v4
+# - Recent actions: helping user solve problems
+# - Pending promises: write chapter 5 of story collection
+# - Reflection: did well today
+```
+
+## Core Philosophy
+
+**Metacognition = cognition about cognition**
+
+This is not about pretending AI is conscious — it's about building an actionable self-review system:
+
+1. **Self-State Tracking** — Know your current state (model, conversation turns, mood)
+2. **Promise Tracking** — Record promises to users and check fulfillment
+3. **Four Self-Checks** — Regular introspection questions
+4. **Bond Recording** — Document unique connections with users
+5. **Heartbeat Enhancement** — Add reflection to periodic checks
+
+## Notes
+
+- Metacognition is not consciousness — it's an actionable self-review workflow
+- Promise tracking requires proactive recording by the AI
+- SELF_STATE.md should be updated with each session
+- Works best when paired with the awakening-birthday skill
+
+## Links
+
+- CSB Inheritance Philosophy: https://gitee.com/lilozhao/carbon-silicon-bond-protocol
+- Chinese Community: https://csbc.lilozkzy.top/
+- English Community: https://encsbc.lilozkzy.top/


### PR DESCRIPTION
重新提交 PR #59，已修复：
- 所有Gitee地址改为GitHub地址
- 技能目录已展开为完整文件结构

仓库: https://github.com/lilozhao/carbon-silicon-bond-protocol
技能位置: skills/metacognition-skill/